### PR TITLE
Pass ext_net_id variable to fip ping neutron tests

### DIFF
--- a/neutron-config-vars.yml
+++ b/neutron-config-vars.yml
@@ -109,7 +109,7 @@ scenarios:
     num_vms: 4
     image_name: cirros
     flavor_name: m1.xtiny
-    ext_net_id:
+    ext_net_id: '{{ ext_net_id }}'
 
  - name: router-subnet-create-delete
    enabled: true


### PR DESCRIPTION
This test was not aware of proper external_id. Because of
it it was failing all the time.