### PR TITLE
Add missing variable

### DIFF
--- a/jetpack_all.yml
+++ b/jetpack_all.yml
@@ -132,6 +132,7 @@ vm_image_url:
 shift_stack: false
 novaless_prov: false
 new_nodes_instack: "{{ playbook_dir }}/newnodes.json"
+vlan_provider_network: false
 
 # This feature creates VMs on hypervisors and uses them as overcloud
 # compute nodes to simulate overcloud scale deployment. This feature


### PR DESCRIPTION
Recent change in jetpack/prepare_nic_configs.yml requires us
to add new variable in jetpack_all.yml file, as Ansible complains
now about it being undefined. This change fixes it.

The commit in jetpack repository that causes this issue:
89c909f3b2f93de0136245784d75092cf06e1dfe